### PR TITLE
Remove deprecated config entries that were in warnings.

### DIFF
--- a/config
+++ b/config
@@ -39,20 +39,8 @@ glx-copy-from-front = false;
 # Probably could improve performance on rapid window content changes, but is known to break things on some drivers (LLVMpipe).
 # Recommended if it works.
 glx-no-rebind-pixmap = true;
-use-damage = false
+use-damage = true;
 
-
-# GLX backend: GLX buffer swap method we assume.
-# Could be undefined (0), copy (1), exchange (2), 3-6, or buffer-age (-1).
-# undefined is the slowest and the safest, and the default value.
-# copy is fastest, but may fail on some drivers,
-# 2-6 are gradually slower but safer (6 is still faster than 0).
-# Usually, double buffer means 2, triple buffer means 3.
-# buffer-age means auto-detect using GLX_EXT_buffer_age, supported by some drivers.
-# Useless with --glx-use-copysubbuffermesa.
-# Partially breaks --resize-damage.
-# Defaults to undefined.
-glx-swap-method = "buffer-age";
 
 #################################
 #
@@ -62,12 +50,6 @@ glx-swap-method = "buffer-age";
 
 # Enabled client-side shadows on windows.
 shadow = true;
-# Don't draw shadows on DND windows.
-no-dnd-shadow = true;
-# Avoid drawing shadows on dock/panel windows.
-no-dock-shadow = false;
-# Zero the part of the shadow's mask behind the window. Fix some weirdness with ARGB windows.
-clear-shadow = true;
 # The blur radius for shadows. (default 12)
 shadow-radius = 7;
 # The left offset for shadows. (default -15)
@@ -115,12 +97,10 @@ shadow-ignore-shaped = false;
 #
 #################################
 
-menu-opacity = 1;
 inactive-opacity = 1;
 active-opacity = 1;
 frame-opacity = 1;
 inactive-opacity-override = false;
-alpha-step = 0.06;
 
 # Dim inactive windows. (0.0 - 1.0)
 inactive-dim = 0.03;
@@ -182,21 +162,11 @@ detect-client-opacity = true;
 # If not specified or 0, compton will try detecting this with X RandR extension.
 refresh-rate = 0;
 
-# Set VSync method. VSync methods currently available:
-# none: No VSync
-# drm: VSync with DRM_IOCTL_WAIT_VBLANK. May only work on some drivers.
-# opengl: Try to VSync with SGI_video_sync OpenGL extension. Only work on some drivers.
-# opengl-oml: Try to VSync with OML_sync_control OpenGL extension. Only work on some drivers.
-# opengl-swc: Try to VSync with SGI_swap_control OpenGL extension. Only work on some drivers. Works only with GLX backend. Known to be most effective on many drivers. Does not actually control paint timing, only buffer swap is affected, so it doesn’t have the effect of --sw-opti unlike other methods. Experimental.
-# opengl-mswc: Try to VSync with MESA_swap_control OpenGL extension. Basically the same as opengl-swc above, except the extension we use.
-# (Note some VSync methods may not be enabled at compile time.)
-vsync = "opengl-swc";
+vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-# Painting on X Composite overlay window. Recommended.
-paint-on-overlay = true;
 
 # Limit compton to repaint at most once every 1 / refresh_rate second to boost performance.
 # This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,


### PR DESCRIPTION
Removed the deprecated config entries that were in Compton startup warnings. Shows no warnings on startup for me now. 
From issue: https://github.com/regolith-linux/regolith-desktop/issues/237