### PR TITLE
read config location from xresources, use exec

### DIFF
--- a/init
+++ b/init
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-if [[ -f "$HOME/.config/regolith/compton/config" ]]; then
-  /usr/bin/compton -f --config $HOME/.config/regolith/compton/config
-else
-  /usr/bin/compton -f --config /etc/regolith/compton/config
-fi
+declare -r CONFIG="$(xrdb -query | grep '^i3-wm.compton.config:' | cut -f2)"
+
+exec /usr/bin/compton -f --config "${CONFIG:-/etc/regolith/compton/config}"


### PR DESCRIPTION
It felt a bit weird that to specify the config location I had to edit a file outside my home directory. The existing logic of "use what's in $HOME if it exists" certainly covers most use cases, but was inconsistent with things like how i3xrocks uses xresources for the config location. I don't see why we can't do the same for compton :)

Additionally if we use `exec` we can avoid leaving around an extra bash process. I'm not sure if that was deliberate or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/regolith-linux/regolith-compositor-compton-glx/2)
<!-- Reviewable:end -->
